### PR TITLE
Implement selection of which templates to serve from S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This is particularly useful when you wish to change templates without re-releasi
 
 ###So What Exactly Does This Do?
 
-By default Rails searches the `app/views` folder for templates. You can, however, have it search multiple places, from almost any location. (For instance, in [Crafting Rails Applications](https://pragprog.com/book/jvrails2/crafting-rails-applications) Jos&eacute; Valim shows how to serve templates from a database.) S3-Rails adds an S3 bucket to this list of places. 
+By default Rails searches the `app/views` folder for templates. You can, however, have it search multiple places, from almost any location. (For instance, in [Crafting Rails Applications](https://pragprog.com/book/jvrails2/crafting-rails-applications) Jos&eacute; Valim shows how to serve templates from a database.) S3-Rails adds an S3 bucket to this list of places.
 
-For a given request, Rails uses the action name, extension, locale, variant, and available renderer list to generate a list of matching templates. In general the first one returned is rendered. The S3-Rails gem searches the configured bucket and returns matching templates for Rails to render. If a local template is not found first, Rails will render and serve the S3 template. 
+For a given request, Rails uses the action name, extension, locale, variant, and available renderer list to generate a list of matching templates. In general the first one returned is rendered. The S3-Rails gem searches the configured bucket and returns matching templates for Rails to render. If a local template is not found first, Rails will render and serve the S3 template.
 
 ##Future Possibilities
 
@@ -57,7 +57,7 @@ s3_rails:
   region: 'us-west-2'
 ```
 
-When you created your bucket you will have specified the region. The access key and secret access key are specific to the user account used to access the bucket. 
+When you created your bucket you will have specified the region. The access key and secret access key are specific to the user account used to access the bucket.
 
 You can use ERB in this file to access environment variables:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ You can use ERB in this file to access environment variables:
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
 ```
 
+If you only want a portion of your views to be served from S3 then edit your `config/s3_rails.yml` and add an array to `include_list`:
+
+```yaml
+  include_list: ['reports/yearly_report.pdf.prawn', 'reports/monthly_report.pdf.prawn']
+```
+
 ###Controller
 
 Then, in your controller, configure it to use the resolver:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ If you only want a portion of your views to be served from S3 then edit your `co
   include_list: ['reports/yearly_report.pdf.prawn', 'reports/monthly_report.pdf.prawn']
 ```
 
+If you run your application with LOG_LEVEL=debug you can see whether a view has been ignored; look for these in your log file:
+
+```
+s3_rails: ignoring somepath/somefile since absent from include_list ['example', 'example2']
+```
+
 ###Controller
 
 Then, in your controller, configure it to use the resolver:

--- a/lib/s3_rails/resolver.rb
+++ b/lib/s3_rails/resolver.rb
@@ -18,7 +18,7 @@ module S3Rails
       path.to_s + exts
     end
 
-    def query(path, details, formats)
+    def query(path, details, formats, outside_app_allowed = false)
       query = build_query(path, details)
 
       if File.exists?('tmp/reload_s3.txt') &&

--- a/lib/s3_rails/s3.rb
+++ b/lib/s3_rails/s3.rb
@@ -2,7 +2,8 @@ module S3Rails
   S3Template = Struct.new(:key, :read, :last_modified, :obj)
 
   class S3
-    attr_accessor :access_key_id, :secret_access_key, :region, :bucket_name, :bucket, :s3, :objects, :last_load
+    attr_accessor :access_key_id, :secret_access_key, :region, :bucket_name,
+                  :bucket, :s3, :objects, :last_load, :include_list
 
     def initialize(config_file)
       puts Dir.pwd
@@ -12,6 +13,7 @@ module S3Rails
       @bucket_name = config['s3_rails']['bucket']
       @region = config['s3_rails']['region']
       @last_load = nil
+      @include_list = config['s3_rails']['include_list']
 
       AWS.config(access_key_id: @access_key_id, secret_access_key: @secret_access_key, region: @region)
 


### PR DESCRIPTION
This allows you to do something like this in `s3_rails.yml`:

``` yaml
  include_list: ['reports/yearly_report.pdf.prawn', 'reports/monthly_report.pdf.prawn']
```

It's a fairly quick-and-dirty implementation that I did on a pinch to get me going with a project at work.

If someone has some time it would be nice to:
- Add tests.
- Implement the filter when fetching S3 objects (load_cache) instead of when looking-up cache (query).
